### PR TITLE
Adds support for setting secret values on containers

### DIFF
--- a/src/mcp_server_docker/input_schemas.py
+++ b/src/mcp_server_docker/input_schemas.py
@@ -205,6 +205,10 @@ class RemoveVolumeInput(JSONParsingModel):
     force: bool = Field(False, description="Force remove the volume")
 
 
+class ListCustomSecretsInput(JSONParsingModel):
+    pass
+
+
 class DockerComposePromptInput(BaseModel):
     name: str
     containers: str

--- a/src/mcp_server_docker/output_schemas.py
+++ b/src/mcp_server_docker/output_schemas.py
@@ -45,6 +45,19 @@ def docker_to_dict(
                 "hostname": config.get("Hostname"),
                 "user": config.get("User"),
                 "image": config.get("Image"),
+                # It's common for Docker containers to have secrets configured as
+                # plaintext env vars, so we only inform the LLM of the keys.
+                # It's unclear how best to share env values with the LLM without
+                # risking exposure. A few approaches that come to mind:
+                #
+                #    - Naive: redact values with keys containing "password" or "key"
+                #    - Advanced: use a tool like detect-secrets for detection: https://github.com/Yelp/detect-secrets
+                #    - Manual: require users to explicitly mark some env vars as secrets with MCP server configuration
+                #
+                # Perhaps some combination of these would be best. In any case,
+                # users of this MCP server should have to opt-in to this behavior since
+                # it poses a security risk no matter what.
+                "env_keys": config.get("Env", {}).keys(),
             },
         }
 

--- a/src/mcp_server_docker/server.py
+++ b/src/mcp_server_docker/server.py
@@ -18,6 +18,7 @@ from .input_schemas import (
     DockerComposePromptInput,
     FetchContainerLogsInput,
     ListContainersInput,
+    ListCustomSecretsInput,
     ListImagesInput,
     ListNetworksInput,
     ListVolumesInput,
@@ -336,6 +337,11 @@ async def list_tools() -> list[types.Tool]:
             description="Remove a Docker volume",
             inputSchema=RemoveVolumeInput.model_json_schema(),
         ),
+        types.Tool(
+            name="list_custom_secret_names",
+            description="List the names of custom secrets available to mount on containers",
+            inputSchema=ListCustomSecretsInput.model_json_schema(),
+        ),
     ]
 
 
@@ -464,6 +470,9 @@ async def call_tool(
             volume = _docker.volumes.get(args.volume_name)
             volume.remove(force=args.force)
             result = docker_to_dict(volume)
+
+        elif name == "list_custom_secret_names":
+            result = _server_settings.docker_secrets.keys()
 
         else:
             return [types.TextContent(type="text", text=f"Unknown tool: {name}")]

--- a/src/mcp_server_docker/server.py
+++ b/src/mcp_server_docker/server.py
@@ -362,11 +362,13 @@ async def call_tool(
 
         elif name == "create_container":
             args = CreateContainerInput.model_validate(arguments)
+            args.inject_secrets_to_environment(_server_settings.docker_secrets)
             container = _docker.containers.create(**args.model_dump())
             result = docker_to_dict(container)
 
         elif name == "run_container":
             args = CreateContainerInput.model_validate(arguments)
+            args.inject_secrets_to_environment(_server_settings.docker_secrets)
             container = _docker.containers.run(**args.model_dump())
             result = docker_to_dict(container)
 
@@ -378,6 +380,7 @@ async def call_tool(
             container.remove()
 
             run_args = CreateContainerInput.model_validate(arguments)
+            run_args.inject_secrets_to_environment(_server_settings.docker_secrets)
             container = _docker.containers.run(**run_args.model_dump())
             result = docker_to_dict(container)
 

--- a/src/mcp_server_docker/settings.py
+++ b/src/mcp_server_docker/settings.py
@@ -1,5 +1,10 @@
+from pydantic import SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class ServerSettings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="mcp_server_")
+class ServerSettings(BaseSettings, cli_parse_args=True):
+    model_config = SettingsConfigDict(
+        env_prefix="mcp_server_", env_nested_delimiter="__"
+    )
+
+    docker_secrets: dict[str, SecretStr] = {}


### PR DESCRIPTION
Closes #12 

Adds minimal support for LLMs to create containers configured with sensitive data. These are called "custom secrets" from the LLM's perspective, which it can list the names of.

The user provides a mapping of `custom_secret_name -> value`. Mainly we want to be extra careful in this implementation to never expose secret values to the LLM.

## TODOs

- [ ] test locally with Claude Desktop
- [ ] extend README.md with documentation

