### PR TITLE
Add LICENSE to Docker image and clean up project metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 COPY ./src /app/src
 COPY README.md ./README.md
+COPY LICENSE ./LICENSE
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,9 @@ requires-python = ">=3.12"
 dependencies = ["docker>=7.1.0", "mcp>=1.1.0", "pydantic-settings>=2.6.1"]
 license = { file = "LICENSE" }
 keywords = ["docker", "mcp", "server"]
-
-requires-python = ">=3.12"
-
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
 ]
 
 [project.urls]


### PR DESCRIPTION
# Add project license and clean up metadata

## Description
This PR makes the following improvements to project metadata and Docker configuration:
- Adds the LICENSE file to the Docker image build
- Cleans up pyproject.toml by removing duplicate `requires-python` entry
- Fixes formatting of classifiers list

## Changes
- Added `COPY LICENSE ./LICENSE` to Dockerfile
- Removed duplicate `requires-python` in pyproject.toml
- Fixed classifiers list formatting in pyproject.toml

## Motivation
These changes ensure:
- License is properly included in the Docker image
- Project metadata is clean and consistent
- Better maintainability of project configuration files

## Testing
- Docker image builds successfully with the new LICENSE file
- Project metadata remains valid according to PEP 621 standards