### PR TITLE
Remove duplicate key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "mcp-server-docker"
 version = "0.1.0"
 description = "A Docker MCP Server"
 readme = "README.md"
-requires-python = ">=3.12"
 dependencies = ["docker>=7.1.0", "mcp>=1.1.0", "pydantic-settings>=2.6.1"]
 license = { file = "LICENSE" }
 keywords = ["docker", "mcp", "server"]


### PR DESCRIPTION
Removed duplicated `requires-python` key

Results in the following error on run
```shell
warning: Failed to parse `pyproject.toml` during settings discovery:
  TOML parse error at line 11, column 1
     |
  11 | requires-python = ">=3.12"
     | ^
  duplicate key `requires-python` in table `project`

error: Failed to parse: `pyproject.toml`
  Caused by: TOML parse error at line 11, column 1
   |
11 | requires-python = ">=3.12"
   | ^
duplicate key `requires-python` in table `project`
```