### PR TITLE
Add filter option for fetching container logs

### DIFF
--- a/src/mcp_server_docker/input_schemas.py
+++ b/src/mcp_server_docker/input_schemas.py
@@ -61,6 +61,9 @@ class FetchContainerLogsInput(JSONParsingModel):
     tail: int | Literal["all"] = Field(
         100, description="Number of lines to show from the end"
     )
+    filter_string: str | None = Field(
+        None, description="Optional string to filter log lines by"
+    )
 
 
 class ListContainersFilters(JSONParsingModel):

--- a/src/mcp_server_docker/server.py
+++ b/src/mcp_server_docker/server.py
@@ -268,7 +268,7 @@ async def list_tools() -> list[types.Tool]:
         ),
         types.Tool(
             name="fetch_container_logs",
-            description="Fetch logs for a Docker container",
+            description="Fetch logs for a Docker container, with an optional string to filter logs by.",
             inputSchema=FetchContainerLogsInput.model_json_schema(),
         ),
         types.Tool(
@@ -396,8 +396,10 @@ async def call_tool(
         elif name == "fetch_container_logs":
             args = FetchContainerLogsInput(**arguments)
             container = _docker.containers.get(args.container_id)
-            logs = container.logs(tail=args.tail).decode("utf-8")
-            result = {"logs": logs.split("\n")}
+            logs = container.logs(tail=args.tail).decode("utf-8").split("\n")
+            if args.filter_string:
+                logs = [line for line in logs if args.filter_string in line]
+            result = {"logs": logs}
 
         elif name == "list_images":
             args = ListImagesInput(**arguments)


### PR DESCRIPTION
Enhanced the `fetch_container_logs` tool by adding an optional `filter_string` parameter to filter log lines. Updated the tool description to reflect this new functionality.