### PR TITLE
Fix: Add allowed_containers field to ServerSettings

### DIFF
--- a/src/mcp_server_docker/settings.py
+++ b/src/mcp_server_docker/settings.py
@@ -1,5 +1,11 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field
 
 
 class ServerSettings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="mcp_server_")
+    model_config = SettingsConfigDict(
+        env_prefix="mcp_server_",
+        case_sensitive=False
+    )
+
+    allowed_containers: list[str] = Field(default_factory=lambda: ["*"])


### PR DESCRIPTION
## Problem
The ALLOWED_CONTAINERS environment variable was ignored, causing only 1 tool to be discovered instead of 18. The server fell back to `laravel_app` as default.

## Root Cause
The `allowed_containers` field was missing from the [ServerSettings](cci:2://file:///D:/projekte/mcp-server-docker/src/mcp_server_docker/settings.py:4:0-10:72) class in [settings.py](cci:7://file:///D:/projekte/mcp-server-docker/src/mcp_server_docker/settings.py:0:0-0:0). Only `env_prefix="mcp_server_"` was configured, but no field existed to receive the environment variable.

## Fix
- Added `allowed_containers` field with default `["*"]` to allow all containers
- Set `case_sensitive=False` in `SettingsConfigDict` for proper environment variable parsing
- Now `MCP_SERVER_ALLOWED_CONTAINERS` environment variable is correctly read

## Testing
- Verified that the field is now properly defined in ServerSettings
- Environment variable parsing works with Pydantic v2