### PR TITLE
Omit unset values from Docker SDK filters

### DIFF
--- a/src/mcp_server_docker/server.py
+++ b/src/mcp_server_docker/server.py
@@ -72,6 +72,13 @@ def _client(ctx: Context[AppContext]) -> docker.DockerClient:
     return ctx.request_context.lifespan_context.docker
 
 
+def _docker_filters(model: BaseModel | None) -> dict[str, Any] | None:
+    """Return Docker SDK filters without unset optional values."""
+    if model is None:
+        return None
+    return model.model_dump(exclude_none=True)
+
+
 @asynccontextmanager
 async def lifespan(_: MCPServer[AppContext]) -> AsyncIterator[AppContext]:
     """Create and close the Docker client for one server lifetime."""
@@ -243,7 +250,7 @@ def list_containers(
     return [
         docker_to_dict(container)
         for container in _client(ctx).containers.list(
-            all=all, filters=filters.model_dump() if filters else None
+            all=all, filters=_docker_filters(filters)
         )
     ]
 
@@ -495,7 +502,7 @@ def list_images(
     return [
         docker_to_dict(image)
         for image in _client(ctx).images.list(
-            name=name, all=all, filters=filters.model_dump() if filters else None
+            name=name, all=all, filters=_docker_filters(filters)
         )
     ]
 
@@ -575,7 +582,7 @@ def list_networks(
     return [
         docker_to_dict(network)
         for network in _client(ctx).networks.list(
-            filters=filters.model_dump() if filters else None
+            filters=_docker_filters(filters)
         )
     ]
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -143,6 +143,8 @@ async def test_tools_have_flat_schemas_and_container_call_semantics(
 
         await client.call_tool("list_containers", {})
         assert docker_client.call("containers.list") == {"all": False, "filters": None}
+        await client.call_tool("list_containers", {"filters": {}})
+        assert docker_client.call("containers.list") == {"all": False, "filters": {}}
         await client.call_tool(
             "list_containers", {"all": True, "filters": {"label": ["a=b"]}}
         )
@@ -206,7 +208,7 @@ async def test_image_network_and_volume_call_semantics(server, docker_client):
         assert docker_client.call("images.list") == {
             "name": "alpine",
             "all": True,
-            "filters": {"dangling": True, "label": None},
+            "filters": {"dangling": True},
         }
         await client.call_tool("pull_image", {"repository": "alpine", "tag": "3.20"})
         assert docker_client.call("images.pull") == ("alpine", {"tag": "3.20"})
@@ -223,6 +225,8 @@ async def test_image_network_and_volume_call_semantics(server, docker_client):
         }
         await client.call_tool("remove_image", {"image": "test", "force": True})
         assert docker_client.call("images.remove") == {"image": "test", "force": True}
+        await client.call_tool("list_networks", {"filters": {}})
+        assert docker_client.call("networks.list") == {"filters": {}}
         await client.call_tool("list_networks", {"filters": {"label": ["x=y"]}})
         assert docker_client.call("networks.list") == {"filters": {"label": ["x=y"]}}
         await client.call_tool("create_network", {"name": "n", "internal": True})


### PR DESCRIPTION
## Summary

Omit unset optional fields when converting typed MCP filter models into Docker SDK filter dictionaries.

## Problem

`ListImagesFilters(dangling=True)` currently becomes `{"dangling": true, "label": null}`. With Docker SDK 7.1.0 against a live daemon, that changes the result from the expected dangling-image set to an empty result.

Observed against the same daemon:

- `{"dangling": true}` -> 29 images
- `{"dangling": true, "label": null}` -> 0 images
- `{"dangling": true, "label": []}` -> 29 images

The same issue can affect the optional label fields on container and network filters.

## Change

Add one small `_docker_filters()` normalization boundary using `model_dump(exclude_none=True)` and use it for container, image and network list calls.

The hermetic tests now verify that empty filter objects remain empty and that a dangling-only image filter reaches the Docker SDK as exactly `{"dangling": true}`.

## Validation

- `ruff check src tests`
- `pytest -q`: 6 passed
- Independently reproduced against Docker SDK 7.1.0 and a live Docker daemon.
