### PR TITLE
Clean up Docker build intermediates

### DIFF
--- a/src/mcp_server_docker/server.py
+++ b/src/mcp_server_docker/server.py
@@ -541,7 +541,9 @@ def build_image(
     tag: Annotated[str, Field(description="Image tag")],
     dockerfile: Annotated[str | None, Field(description="Path to Dockerfile")] = None,
 ) -> dict[str, Any]:
-    image, logs = _client(ctx).images.build(path=path, tag=tag, dockerfile=dockerfile)
+    image, logs = _client(ctx).images.build(
+        path=path, tag=tag, dockerfile=dockerfile, rm=True, forcerm=True
+    )
     return {"image": docker_to_dict(image), "logs": list(logs)}
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -220,6 +220,8 @@ async def test_image_network_and_volume_call_semantics(server, docker_client):
             "path": ".",
             "tag": "test",
             "dockerfile": "Dockerfile.test",
+            "rm": True,
+            "forcerm": True,
         }
         await client.call_tool("remove_image", {"image": "test", "force": True})
         assert docker_client.call("images.remove") == {"image": "test", "force": True}


### PR DESCRIPTION
## Summary

Pass Docker SDK `rm=True` and `forcerm=True` from the `build_image` tool so intermediate containers are removed on both successful and failed image builds.

## Problem

`docker.images.build()` defaults do not force intermediate-container cleanup. Repeated MCP builds can therefore leave non-Compose intermediate containers behind, especially after failures.

## Change

Add the two Docker SDK cleanup flags to the existing build call and extend the hermetic call-contract assertion.

## Validation

- `ruff check src tests`
- `pytest -q`: 6 passed
- Live validation against the same Docker daemon covered both a successful build and an intentionally failing Dockerfile; both paths left zero new containers after the invocation.
