### PR TITLE
Handle attached Docker run output

### DIFF
--- a/src/mcp_server_docker/server.py
+++ b/src/mcp_server_docker/server.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Annotated, Any, Literal
 
 import docker
+from docker.models.containers import Container
 from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
@@ -70,6 +71,20 @@ AutoRemove = Annotated[bool, Field(description="Automatically remove the contain
 
 def _client(ctx: Context[AppContext]) -> docker.DockerClient:
     return ctx.request_context.lifespan_context.docker
+
+
+def _run_result(value: Any, *, detach: bool) -> dict[str, Any]:
+    """Normalize Docker SDK run results for attached and detached execution."""
+    if isinstance(value, Container):
+        return docker_to_dict(value)
+    if detach:
+        raise TypeError(f"Detached Docker run returned unexpected type: {type(value)}")
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return {
+            "mode": "attached",
+            "output": bytes(value).decode("utf-8", errors="replace"),
+        }
+    raise TypeError(f"Attached Docker run returned unexpected type: {type(value)}")
 
 
 @asynccontextmanager
@@ -345,21 +360,20 @@ def run_container(
         bool, Field(description="Automatically remove the container")
     ] = False,
 ) -> dict[str, Any]:
-    return docker_to_dict(
-        _client(ctx).containers.run(
-            image=image,
-            detach=detach,
-            name=name,
-            entrypoint=entrypoint,
-            command=command,
-            network=network,
-            environment=environment,
-            ports=ports,
-            volumes=volumes,
-            labels=labels,
-            auto_remove=auto_remove,
-        )
+    result = _client(ctx).containers.run(
+        image=image,
+        detach=detach,
+        name=name,
+        entrypoint=entrypoint,
+        command=command,
+        network=network,
+        environment=environment,
+        ports=ports,
+        volumes=volumes,
+        labels=labels,
+        auto_remove=auto_remove,
     )
+    return _run_result(result, detach=detach)
 
 
 @app.tool(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -58,6 +58,8 @@ class Collection:
 
     def run(self, **kwargs):
         self.calls.append((f"{self.name}.run", kwargs))
+        if kwargs.get("detach") is False:
+            return b"attached\xff\n"
         return Object(self.calls)
 
 
@@ -156,8 +158,12 @@ async def test_tools_have_flat_schemas_and_container_call_semantics(
         )
         assert docker_client.call("containers.create")["image"] == "alpine"
         assert docker_client.call("containers.create")["environment"] == {"X": "1"}
-        await client.call_tool("run_container", {"image": "alpine", "detach": False})
+        attached = await client.call_tool("run_container", {"image": "alpine", "detach": False})
         assert docker_client.call("containers.run")["detach"] is False
+        assert attached.structured_content == {
+            "mode": "attached",
+            "output": "attached\ufffd\n",
+        }
         await client.call_tool("recreate_container", {"image": "alpine", "name": "old"})
         assert docker_client.call("containers.get") == "old"
         assert [name for name, _ in docker_client.calls[-4:]] == [


### PR DESCRIPTION
## Summary

Handle the Docker SDK return type for `run_container(detach=false)` instead of passing attached command output to `docker_to_dict()`.

## Problem

`docker.containers.run(..., detach=False)` returns command output bytes. The current tool always calls `docker_to_dict()` on the result, which only supports Docker model objects, so attached execution fails during result conversion even when the command itself succeeded.

## Change

- Preserve the existing Docker-object response for detached execution.
- Return attached command output as structured `{mode: "attached", output: ...}` data.
- Decode invalid UTF-8 using replacement rather than failing result serialization.
- Reject unexpected return types explicitly.

This PR intentionally does not add output-size policy; it only fixes the Docker SDK type contract.

## Validation

- `ruff check src tests`
- `pytest -q`: 6 passed
- Live MCP validation with `alpine:latest` and `detach=false` returned the expected command output successfully.
